### PR TITLE
Make project name argument optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 env
 .vscode
+*.csv
+*.log


### PR DESCRIPTION
Allows getting the data from all available projects if `--project` argument is not provided or empty.
**NB!** Issues parsing can take a lot of time if we select data within the large timeframe and without a specified project name.

Changes:
- Moved csv and log files to gitignore;
- Made `--project` argument optional;
- Added logic of looping through all available Jira projects in case `--project` is not provided